### PR TITLE
Soc29/round outputs

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from logger import logger
 
 
 def load_cd_baby(filepath):
@@ -21,11 +22,11 @@ def load_cd_baby(filepath):
     return df
 
 
-def load_distrokid(filepath): 
+def load_distrokid(filepath) -> pd.DataFrame:
     """Loader for a data file exported from DistroKid
     """
     df = pd.read_csv(
-        filepath, 
+        filepath,
         delimiter='\t',
         parse_dates=[0],
         usecols=[1, 2, 7, 12]
@@ -41,7 +42,7 @@ def load_distrokid(filepath):
 
 
 
-def load_earnings_report(filepath, distributor, service_map_file):
+def load_earnings_report(filepath, distributor, service_map_file) -> pd.DataFrame:
     """Reads earnings report and transforms data, formatting dates,
     and joining streaming company names to use
     """
@@ -50,8 +51,11 @@ def load_earnings_report(filepath, distributor, service_map_file):
         'cd_baby': load_cd_baby,
         'distrokid': load_distrokid
     }
+
+    logger.info('Loading data using distibutor "%s"', distributor)
     data = distributor_loaders.get(distributor)(filepath)
 
+    logger.info('Using service map file: "%s"', service_map_file)
     service_map = pd.read_csv(service_map_file)
     data['Year'] = pd.DatetimeIndex(data['Sales Date']).year
     data['Month'] = pd.DatetimeIndex(data['Sales Date']).month

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -88,7 +88,7 @@ def load_earnings_data() -> None:
         'CD Baby': 'cd_baby', # TODO: add 'DistroKid': 'distrokid'
     }
     distributor_code = distributor_map.get(st.session_state.distributor)
-    partner_map_file = Path('data/partner_map_simplified.csv')
+    service_map_file = Path('data/partner_map_simplified.csv')
 
     if st.session_state.earnings_data_file:
         _file = st.session_state.earnings_data_file
@@ -96,7 +96,7 @@ def load_earnings_data() -> None:
         _file = 'data/sample_data/sample_data_cd_baby.txt'
 
     st.session_state.earnings_data = load_earnings_report(
-        _file, distributor_code, partner_map_file
+        _file, distributor_code, service_map_file
     )
 
 

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pathlib import Path
 import streamlit as st
 from streamlit_echarts import st_echarts
@@ -70,6 +71,9 @@ if 'distributor' not in st.session_state:
 if 'earnings_data_file' not in st.session_state:
     st.session_state.earnings_data_file = None
 
+if 'raw_earnings_data' not in st.session_state:
+    st.session_state.raw_earnings_data = None
+
 if 'transactions' not in st.session_state:
     st.session_state.transactions = ['Stream']
 
@@ -80,6 +84,9 @@ if 'earnings_data' not in st.session_state:
 
 if 'rates_data' not in st.session_state:
     st.session_state.rates_data = None
+
+if 'counts_data' not in st.session_state:
+    st.session_state.counts_data = None
 
 
 def load_earnings_data() -> None:
@@ -95,7 +102,7 @@ def load_earnings_data() -> None:
     else:
         _file = 'data/sample_data/sample_data_cd_baby.txt'
 
-    st.session_state.earnings_data = load_earnings_report(
+    st.session_state.raw_earnings_data = load_earnings_report(
         _file, distributor_code, service_map_file
     )
 
@@ -124,14 +131,13 @@ def run_report():
 
     # Generate summary report
     summary_reports = generate_reports(
-        st.session_state.earnings_data,
+        st.session_state.raw_earnings_data,
         transaction_codes,
         adjust_for_inflation=st.session_state.adjust_for_inflation
     )
 
     # Display plot
     transactions_str = ', '.join(st.session_state.transactions).title()
-
 
     if st.session_state.adjust_for_inflation:
         inflation_str = ' - Adjusted for Inflation'
@@ -216,6 +222,10 @@ def display_page() -> None:
     ---
     """
     )
+    # Downloader filename
+    adjusted = '_adjusted' if st.session_state.adjust_for_inflation else ''
+    timestamp = datetime.now().strftime("%Y%m%d")
+
     st_echarts(
         options=st.session_state.rates_plot_options,
         height="400px",
@@ -226,7 +236,7 @@ def display_page() -> None:
         st.download_button(
             label="Download CSV",
             data=rates_csv,
-            file_name='soc_streaming_rates.csv',
+            file_name=f'soc_streaming_rates{adjusted}_{timestamp}.csv',
             mime='text/csv',
         )
 
@@ -240,7 +250,7 @@ def display_page() -> None:
         st.download_button(
             label="Download CSV",
             data=earnings_csv,
-            file_name='soc_streaming_earnings.csv',
+            file_name=f'soc_streaming_earnings{adjusted}_{timestamp}.csv',
             mime='text/csv',
         )
 
@@ -254,7 +264,7 @@ def display_page() -> None:
         st.download_button(
             label="Download CSV",
             data=counts_csv,
-            file_name='soc_streaming_counts.csv',
+            file_name=f'soc_streaming_counts_{timestamp}.csv',
             mime='text/csv',
         )
     return

--- a/src/utils.py
+++ b/src/utils.py
@@ -14,3 +14,14 @@ def convert_df_to_csv(df: pd.DataFrame):
     Convert a pandas DataFrame to a csv file
     """
     return df.to_csv(index=True).encode('utf-8')
+
+
+def normalize_dataframe_values(df: pd.DataFrame, digits=5) -> pd.DataFrame:
+    """Tries to cast all dataframe values as float and round all values
+    """
+    for c in df.columns:
+        try:
+            df[c] = df[c].astype(float).round(digits)
+        except ValueError:
+            pass
+    return df


### PR DESCRIPTION
- rounds payout data to thousandths of a cent, and count data to whole number
- fixes bug where `st.session_state.earnings_data` was ambiguous
- adds timestamps and `inflation_adjusted` label to output filenames
- other general bug-fixes and lint errors